### PR TITLE
feat: local python runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ BLINK is a minimal chat prototype with a Fastify server and static web client.
    ```
 3. Open `web/index.html` in your browser.
 
+### Python code runner
+
+The web client includes a **Run Py** button. Enter Python code in the text box
+and click it to execute the snippet locally on the server. Output (stdout and
+stderr) is returned as a local response.
+
 ## Privacy
 
 Enable **Privacy Mode** in the web client to force all requests to the local

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,6 +1,7 @@
 import Fastify from 'fastify';
 import { config } from 'dotenv';
 import { routeChat } from './router.js';
+import { runPython } from './python.js';
 
 config();
 process.env.REGION = process.env.REGION || 'AU';
@@ -18,6 +19,13 @@ app.post('/api/chat', async (req, res) => {
   const offline = !!body?.offline;
   const result = await routeChat(messages, privacyMode || offline, req.log);
   return { reply: result.reply, local: result.local };
+});
+
+app.post('/api/python', async (req, res) => {
+  const body = req.body as any;
+  const code = typeof body?.code === 'string' ? body.code : '';
+  const result = await runPython(code);
+  return result;
 });
 
 if (process.env.NODE_ENV !== 'test') {

--- a/server/src/python.ts
+++ b/server/src/python.ts
@@ -1,0 +1,24 @@
+import { spawn } from 'child_process';
+
+export async function runPython(code: string): Promise<{ stdout: string; stderr: string }> {
+  return new Promise(resolve => {
+    const proc = spawn('python', ['-'], { stdio: ['pipe', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => {
+      stderr += '\n[timeout]';
+      proc.kill('SIGKILL');
+    }, 5000);
+    proc.stdout.on('data', d => {
+      stdout += d.toString();
+    });
+    proc.stderr.on('data', d => {
+      stderr += d.toString();
+    });
+    proc.on('close', () => {
+      clearTimeout(timer);
+      resolve({ stdout, stderr });
+    });
+    proc.stdin.end(code);
+  });
+}

--- a/web/index.html
+++ b/web/index.html
@@ -20,11 +20,13 @@
 <label><input type="checkbox" id="privacy"/> Privacy mode</label>
 <textarea id="text" rows="2"></textarea>
 <button id="send">Send</button>
+<button id="runpy">Run Py</button>
 </div>
 <script>
 const chat = document.getElementById('chat');
 const text = document.getElementById('text');
 const send = document.getElementById('send');
+const runpy = document.getElementById('runpy');
 const privacy = document.getElementById('privacy');
 let messages = [];
 function append(role, content, local){
@@ -49,6 +51,21 @@ send.onclick = async () => {
   const data = await res.json();
   messages.push({role:'assistant', content:data.reply});
   append('assistant', data.reply, data.local);
+};
+
+runpy.onclick = async () => {
+  const code = text.value.trim();
+  if(!code) return;
+  append('user', code);
+  text.value='';
+  const res = await fetch('/api/python', {
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({code})
+  });
+  const data = await res.json();
+  const out = (data.stdout || '') + (data.stderr || '');
+  append('assistant', out, true);
 };
 </script>
 </body>


### PR DESCRIPTION
## Summary
- allow server to execute python snippets and return output
- expose new `/api/python` route and Run Py button in web client
- document usage in README

## Testing
- `cd server && npm run typecheck`
- `cd server && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5df16c3048327910da4de96888dbc